### PR TITLE
Fix/conda env

### DIFF
--- a/src/environment_linux.yml
+++ b/src/environment_linux.yml
@@ -1,11 +1,12 @@
 channels:
   - conda-forge
   - pytorch
+  - pyg
 dependencies:
   - python=3.9
   - pytorch
   - torchvision
-  - torch_geometric
+  - pyg
   - einops
   - torchmetrics
   - wandb

--- a/src/template_wandb_config.yaml
+++ b/src/template_wandb_config.yaml
@@ -1,3 +1,3 @@
 host: https://api.wandb.ai/
-entity: uw-sbel
-project: upt_trial
+entity: <ENTITY>
+project: <PROJECT>

--- a/src/template_wandb_config.yaml
+++ b/src/template_wandb_config.yaml
@@ -1,3 +1,3 @@
 host: https://api.wandb.ai/
-entity: <ENTITY>
-project: <PROJECT>
+entity: uw-sbel
+project: upt_trial


### PR DESCRIPTION
The current `environment_linux.yaml` file upon   
`conda env create --file environment_<OS>.yml --name <NAME>`  
fails with the following error:

```bash
Solving environment: failed
 
ResolvePackageNotFound: 
  - torch_geometric
```
This is because the conda package `torch_geometric` is named `pyg` and needs to be installed from channel `-c pyg`. This PR fixes that by replacing `torch_geometric` with `pyg` and adding `pyg` as a channel 